### PR TITLE
Updated reference links to valid URLs in the HTML view

### DIFF
--- a/ogcapi-workspace/html/htmlview.xml
+++ b/ogcapi-workspace/html/htmlview.xml
@@ -4,8 +4,8 @@
           xsi:schemaLocation="http://www.deegree.org/ogcapi/htmlview http://schemas.deegree.org/ogcapi/3.4.0/htmlview.xsd">
 
   <CssFile>../html/lgv.css</CssFile>
-  <LegalNoticeUrl>https://www.lat-lon.de/Impressum.html</LegalNoticeUrl>
-  <PrivacyPolicyUrl>https://www.lat-lon.de/Datenschutz.html</PrivacyPolicyUrl>
+  <LegalNoticeUrl>https://lat-lon.de/en/Imprint.html</LegalNoticeUrl>
+  <PrivacyPolicyUrl>https://lat-lon.de/en/Privacy.html</PrivacyPolicyUrl>
   <Map>
     <WMSUrl version="1.3.0">https://sgx.geodatenzentrum.de/wms_topplus_open</WMSUrl>
     <WMSLayers>web_grau</WMSLayers>

--- a/ogcapi-workspace/html/oaf.xml
+++ b/ogcapi-workspace/html/oaf.xml
@@ -4,9 +4,9 @@
           xsi:schemaLocation="http://www.deegree.org/ogcapi/htmlview http://schemas.deegree.org/ogcapi/3.4.0/htmlview.xsd">
 
   <CssFile>../html/lgv.css</CssFile>
-  <LegalNoticeUrl>https://www.lat-lon.de/Impressum.html</LegalNoticeUrl>
-  <PrivacyPolicyUrl>https://www.lat-lon.de/Datenschutz.html</PrivacyPolicyUrl>
-  <DocumentationUrl>https://oaf.lat-lon.de/deegree-services-oaf/documentation/index.html</DocumentationUrl>
+  <LegalNoticeUrl>https://lat-lon.de/en/Imprint.html</LegalNoticeUrl>
+  <PrivacyPolicyUrl>https://lat-lon.de/en/Privacy.html</PrivacyPolicyUrl>
+  <DocumentationUrl>https://cite.deegree.org/deegree-ogcapi-1.3/documentation/index.html#_usage</DocumentationUrl>
   <Map>
     <WMSUrl version="1.3.0">https://sgx.geodatenzentrum.de/wms_topplus_open</WMSUrl>
     <WMSLayers>web_grau</WMSLayers>


### PR DESCRIPTION
In the landing page configuration (htmlview.xml) the links for "Legal Notice" as well as "Privacy Policy" have been updated to the right path (before they caused an 404). In the dataset page configuration (oaf.xml) the links for "Legal Notice" and "Privacy Policy" have been updated as well. Furthermore the link for the documentation was updated as well.