### PR TITLE
Update configVersion and schemaLocation of demo-workspace to deegree version 3.5

### DIFF
--- a/ogcapi-workspace/datasources/feature/kitaeinrichtung/datasource_kita_kitaeinrichtungen.xml
+++ b/ogcapi-workspace/datasources/feature/kitaeinrichtung/datasource_kita_kitaeinrichtungen.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<SQLFeatureStore configVersion="3.4.0"
-  xmlns="http://www.deegree.org/datasource/feature/sql" 
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  
-  xsi:schemaLocation="http://www.deegree.org/datasource/feature/sql http://schemas.deegree.org/datasource/feature/sql/3.4.0/sql.xsd">
+<SQLFeatureStore configVersion="3.5.0"
+                 xmlns="http://www.deegree.org/datasource/feature/sql"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://www.deegree.org/datasource/feature/sql https://schemas.deegree.org/3.5/datasource/feature/sql/sql.xsd">
+                 
   <JDBCConnId>oaf_db</JDBCConnId>
   <FeatureTypeMapping name="KitaEinrichtungen" table="kita.kita_einrichtung">
     <FIDMapping>

--- a/ogcapi-workspace/datasources/feature/kitaeinrichtung/datasource_kita_kitaeinrichtungen.xml
+++ b/ogcapi-workspace/datasources/feature/kitaeinrichtung/datasource_kita_kitaeinrichtungen.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<SQLFeatureStore configVersion="3.5.0"
-                 xmlns="http://www.deegree.org/datasource/feature/sql"
+<SQLFeatureStore xmlns="http://www.deegree.org/datasource/feature/sql"
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                 xsi:schemaLocation="http://www.deegree.org/datasource/feature/sql https://schemas.deegree.org/3.5/datasource/feature/sql/sql.xsd">
+                 xsi:schemaLocation="http://www.deegree.org/datasource/feature/sql http://schemas.deegree.org/3.5/datasource/feature/sql/sql.xsd">
                  
   <JDBCConnId>oaf_db</JDBCConnId>
   <FeatureTypeMapping name="KitaEinrichtungen" table="kita.kita_einrichtung">

--- a/ogcapi-workspace/datasources/feature/strassenbaumkataster/datasource_strassenbaumkataster.xml
+++ b/ogcapi-workspace/datasources/feature/strassenbaumkataster/datasource_strassenbaumkataster.xml
@@ -1,7 +1,7 @@
-<SQLFeatureStore configVersion="3.4.0"
+<SQLFeatureStore configVersion="3.5.0"
                  xmlns="http://www.deegree.org/datasource/feature/sql"
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                 xsi:schemaLocation="http://www.deegree.org/datasource/feature/sql http://schemas.deegree.org/datasource/feature/sql/3.4.0/sql.xsd">
+                 xsi:schemaLocation="http://www.deegree.org/datasource/feature/sql https://schemas.deegree.org/3.5/datasource/feature/sql/sql.xsd">
 
   <JDBCConnId>oaf_db</JDBCConnId>
   <StorageCRS srid="25832" dim="2D">http://www.opengis.net/def/crs/EPSG/0/25832</StorageCRS>

--- a/ogcapi-workspace/datasources/feature/strassenbaumkataster/datasource_strassenbaumkataster.xml
+++ b/ogcapi-workspace/datasources/feature/strassenbaumkataster/datasource_strassenbaumkataster.xml
@@ -1,7 +1,6 @@
-<SQLFeatureStore configVersion="3.5.0"
-                 xmlns="http://www.deegree.org/datasource/feature/sql"
+<SQLFeatureStore xmlns="http://www.deegree.org/datasource/feature/sql"
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                 xsi:schemaLocation="http://www.deegree.org/datasource/feature/sql https://schemas.deegree.org/3.5/datasource/feature/sql/sql.xsd">
+                 xsi:schemaLocation="http://www.deegree.org/datasource/feature/sql http://schemas.deegree.org/3.5/datasource/feature/sql/sql.xsd">
 
   <JDBCConnId>oaf_db</JDBCConnId>
   <StorageCRS srid="25832" dim="2D">http://www.opengis.net/def/crs/EPSG/0/25832</StorageCRS>

--- a/ogcapi-workspace/html/htmlview.xml
+++ b/ogcapi-workspace/html/htmlview.xml
@@ -1,7 +1,7 @@
-<HtmlView configVersion="3.4.0"
+<HtmlView configVersion="3.5.0"
           xmlns="http://www.deegree.org/ogcapi/htmlview"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:schemaLocation="http://www.deegree.org/ogcapi/htmlview http://schemas.deegree.org/ogcapi/3.4.0/htmlview.xsd">
+          xsi:schemaLocation="http://www.deegree.org/ogcapi/htmlview http://schemas.deegree.org/3.5/ogcapi/htmlview/htmlview.xsd">
 
   <CssFile>../html/lgv.css</CssFile>
   <LegalNoticeUrl>https://lat-lon.de/en/Imprint.html</LegalNoticeUrl>

--- a/ogcapi-workspace/html/htmlview.xml
+++ b/ogcapi-workspace/html/htmlview.xml
@@ -1,5 +1,4 @@
-<HtmlView configVersion="3.5.0"
-          xmlns="http://www.deegree.org/ogcapi/htmlview"
+<HtmlView xmlns="http://www.deegree.org/ogcapi/htmlview"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://www.deegree.org/ogcapi/htmlview http://schemas.deegree.org/3.5/ogcapi/htmlview/htmlview.xsd">
 

--- a/ogcapi-workspace/html/oaf.xml
+++ b/ogcapi-workspace/html/oaf.xml
@@ -1,7 +1,7 @@
-<HtmlView configVersion="3.4.0"
+<HtmlView configVersion="3.5.0"
           xmlns="http://www.deegree.org/ogcapi/htmlview"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:schemaLocation="http://www.deegree.org/ogcapi/htmlview http://schemas.deegree.org/ogcapi/3.4.0/htmlview.xsd">
+          xsi:schemaLocation="http://www.deegree.org/ogcapi/htmlview http://schemas.deegree.org/3.5/ogcapi/htmlview/htmlview.xsd">
 
   <CssFile>../html/lgv.css</CssFile>
   <LegalNoticeUrl>https://lat-lon.de/en/Imprint.html</LegalNoticeUrl>

--- a/ogcapi-workspace/html/oaf.xml
+++ b/ogcapi-workspace/html/oaf.xml
@@ -1,5 +1,4 @@
-<HtmlView configVersion="3.5.0"
-          xmlns="http://www.deegree.org/ogcapi/htmlview"
+<HtmlView xmlns="http://www.deegree.org/ogcapi/htmlview"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://www.deegree.org/ogcapi/htmlview http://schemas.deegree.org/3.5/ogcapi/htmlview/htmlview.xsd">
 

--- a/ogcapi-workspace/jdbc/oaf_db.xml
+++ b/ogcapi-workspace/jdbc/oaf_db.xml
@@ -1,10 +1,10 @@
-<DataSourceConnectionProvider configVersion="3.4.0"
+<DataSourceConnectionProvider configVersion="3.5.0"
                               xmlns="http://www.deegree.org/connectionprovider/datasource"
                               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                              xsi:schemaLocation="http://www.deegree.org/connectionprovider/datasource http://schemas.deegree.org/jdbc/datasource/3.4.0/datasource.xsd">
+                              xsi:schemaLocation="http://www.deegree.org/connectionprovider/datasource http://schemas.deegree.org/3.5/jdbc/datasource/datasource.xsd">
 
   <!-- Creation / lookup of javax.sql.DataSource instance -->
-  <DataSource javaClass="org.apache.commons.dbcp.BasicDataSource" destroyMethod="close"/>
+  <DataSource javaClass="org.apache.commons.dbcp2.BasicDataSource" destroyMethod="close"/>
 
   <!-- Configuration of DataSource properties -->
   <Property name="driverClassName" value="org.postgresql.Driver" />
@@ -12,7 +12,7 @@
   <Property name="username" value="postgres" />
   <Property name="password" value="postgres" />
   <Property name="poolPreparedStatements" value="true" />
-  <Property name="maxActive" value="10" />
+  <Property name="maxTotal" value="10" />
   <Property name="maxIdle" value="10" />
 
 </DataSourceConnectionProvider>

--- a/ogcapi-workspace/jdbc/oaf_db.xml
+++ b/ogcapi-workspace/jdbc/oaf_db.xml
@@ -1,7 +1,6 @@
-<DataSourceConnectionProvider configVersion="3.5.0"
-                              xmlns="http://www.deegree.org/connectionprovider/datasource"
+<DataSourceConnectionProvider xmlns="http://www.deegree.org/connectionprovider/datasource"
                               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                              xsi:schemaLocation="http://www.deegree.org/connectionprovider/datasource http://schemas.deegree.org/3.5/jdbc/datasource/datasource.xsd">
+                              xsi:schemaLocation="http://www.deegree.org/connectionprovider/datasource http://schemas.deegree.org/3.5/connectionprovider/datasource/datasource.xsd">
 
   <!-- Creation / lookup of javax.sql.DataSource instance -->
   <DataSource javaClass="org.apache.commons.dbcp2.BasicDataSource" destroyMethod="close"/>

--- a/ogcapi-workspace/ogcapi/datasets.xml
+++ b/ogcapi-workspace/ogcapi/datasets.xml
@@ -1,7 +1,8 @@
-<Datasets configVersion="3.4.0"
-                        xmlns="http://www.deegree.org/ogcapi/datasets"
-                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                        xsi:schemaLocation="http://www.deegree.org/ogcapi/datasets  http://schemas.deegree.org/ogcapi/datasets/3.4.0/datasets.xsd">
+<Datasets configVersion="3.5.0"
+          xmlns="http://www.deegree.org/ogcapi/datasets"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://www.deegree.org/ogcapi/datasets http://schemas.deegree.org/3.5/ogcapi/datasets/datasets.xsd">
+          
   <Title>Datasets des LGV HH</Title>
   <Description><![CDATA[Testdaten des <a href="https://www.hamburg.de/bsw/landesbetrieb-geoinformation-und-vermessung/" target="_blank">LGV HH</a>]]></Description>
   <Contact>

--- a/ogcapi-workspace/ogcapi/datasets.xml
+++ b/ogcapi-workspace/ogcapi/datasets.xml
@@ -1,5 +1,4 @@
-<Datasets configVersion="3.5.0"
-          xmlns="http://www.deegree.org/ogcapi/datasets"
+<Datasets xmlns="http://www.deegree.org/ogcapi/datasets"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://www.deegree.org/ogcapi/datasets http://schemas.deegree.org/3.5/ogcapi/datasets/datasets.xsd">
           

--- a/ogcapi-workspace/ogcapi/kitaeinrichtung.xml
+++ b/ogcapi-workspace/ogcapi/kitaeinrichtung.xml
@@ -1,9 +1,15 @@
-<deegreeOAF xmlns="http://www.deegree.org/ogcapi/features" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" configVersion="3.4.0" xsi:schemaLocation="http://www.deegree.org/ogcapi/features http://schemas.deegree.org/ogcapi/features/3.4.0/features.xsd">
+<deegreeOAF configVersion="3.5.0"
+            xmlns="http://www.deegree.org/ogcapi/features"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://www.deegree.org/ogcapi/features http://schemas.deegree.org/3.5/ogcapi/features/features.xsd">
+
   <FeatureStoreId>kitaeinrichtung/datasource_kita_kitaeinrichtungen</FeatureStoreId>
+
   <!-- First CRS must be http://www.opengis.net/def/crs/OGC/1.3/CRS84 to be conform to OGC API Features Core -->
   <QueryCRS>http://www.opengis.net/def/crs/OGC/1.3/CRS84</QueryCRS>
   <QueryCRS>http://www.opengis.net/def/crs/EPSG/0/4326</QueryCRS>
   <QueryCRS>http://www.opengis.net/def/crs/EPSG/0/25832</QueryCRS>
+  
   <Metadata>
     <ProviderLicense>
       <Name>Datenlizenz Deutschland Namensnennung 2.0</Name>

--- a/ogcapi-workspace/ogcapi/kitaeinrichtung.xml
+++ b/ogcapi-workspace/ogcapi/kitaeinrichtung.xml
@@ -1,5 +1,4 @@
-<deegreeOAF configVersion="3.5.0"
-            xmlns="http://www.deegree.org/ogcapi/features"
+<deegreeOAF xmlns="http://www.deegree.org/ogcapi/features"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://www.deegree.org/ogcapi/features http://schemas.deegree.org/3.5/ogcapi/features/features.xsd">
 

--- a/ogcapi-workspace/ogcapi/strassenbaumkataster.xml
+++ b/ogcapi-workspace/ogcapi/strassenbaumkataster.xml
@@ -1,5 +1,4 @@
-<deegreeOAF configVersion="3.5.0"
-            xmlns="http://www.deegree.org/ogcapi/features"
+<deegreeOAF xmlns="http://www.deegree.org/ogcapi/features"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://www.deegree.org/ogcapi/features http://schemas.deegree.org/3.5/ogcapi/features/features.xsd">
 

--- a/ogcapi-workspace/ogcapi/strassenbaumkataster.xml
+++ b/ogcapi-workspace/ogcapi/strassenbaumkataster.xml
@@ -1,10 +1,10 @@
-<deegreeOAF configVersion="3.4.0"
+<deegreeOAF configVersion="3.5.0"
             xmlns="http://www.deegree.org/ogcapi/features"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xsi:schemaLocation="http://www.deegree.org/ogcapi/features http://schemas.deegree.org/ogcapi/features/3.4.0/features.xsd">
+            xsi:schemaLocation="http://www.deegree.org/ogcapi/features http://schemas.deegree.org/3.5/ogcapi/features/features.xsd">
 
   <FeatureStoreId>strassenbaumkataster/datasource_strassenbaumkataster</FeatureStoreId>
-
+  
   <!-- First CRS must be http://www.opengis.net/def/crs/OGC/1.3/CRS84 to be conform to OGC API Features Core -->
   <QueryCRS>http://www.opengis.net/def/crs/OGC/1.3/CRS84</QueryCRS>
   <QueryCRS>http://www.opengis.net/def/crs/EPSG/0/4326</QueryCRS>

--- a/ogcapi-workspace/services/kitaeinrichtung_metadata.xml
+++ b/ogcapi-workspace/services/kitaeinrichtung_metadata.xml
@@ -1,7 +1,6 @@
-<deegreeServicesMetadata configVersion="3.5.0"
-                         xmlns="http://www.deegree.org/services/metadata"
+<deegreeServicesMetadata xmlns="http://www.deegree.org/services/metadata"
                          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                         xsi:schemaLocation="http://www.deegree.org/services/metadata https://schemas.deegree.org/3.5/services/metadata/metadata.xsd">
+                         xsi:schemaLocation="http://www.deegree.org/services/metadata http://schemas.deegree.org/3.5/services/metadata/metadata.xsd">
 
   <ServiceIdentification>
     <Title>Kita Einrichtungen Hamburg</Title>

--- a/ogcapi-workspace/services/kitaeinrichtung_metadata.xml
+++ b/ogcapi-workspace/services/kitaeinrichtung_metadata.xml
@@ -1,4 +1,8 @@
-<deegreeServicesMetadata xmlns="http://www.deegree.org/services/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" configVersion="3.4.0" xsi:schemaLocation="http://www.deegree.org/services/metadata http://schemas.deegree.org/services/metadata/3.4.0/metadata.xsd">
+<deegreeServicesMetadata configVersion="3.5.0"
+                         xmlns="http://www.deegree.org/services/metadata"
+                         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                         xsi:schemaLocation="http://www.deegree.org/services/metadata https://schemas.deegree.org/3.5/services/metadata/metadata.xsd">
+
   <ServiceIdentification>
     <Title>Kita Einrichtungen Hamburg</Title>
     <Abstract><![CDATA[Es werden täglich zwei Dateien generiert:

--- a/ogcapi-workspace/services/strassenbaumkataster_metadata.xml
+++ b/ogcapi-workspace/services/strassenbaumkataster_metadata.xml
@@ -1,7 +1,7 @@
-<deegreeServicesMetadata configVersion="3.4.0"
+<deegreeServicesMetadata configVersion="3.5.0"
                          xmlns="http://www.deegree.org/services/metadata"
                          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                         xsi:schemaLocation="http://www.deegree.org/services/metadata http://schemas.deegree.org/services/metadata/3.4.0/metadata.xsd">
+                         xsi:schemaLocation="http://www.deegree.org/services/metadata https://schemas.deegree.org/3.5/services/metadata/metadata.xsd">
 
   <ServiceIdentification>
     <Title>Strassenbaumkataster Hamburg</Title>

--- a/ogcapi-workspace/services/strassenbaumkataster_metadata.xml
+++ b/ogcapi-workspace/services/strassenbaumkataster_metadata.xml
@@ -1,7 +1,6 @@
-<deegreeServicesMetadata configVersion="3.5.0"
-                         xmlns="http://www.deegree.org/services/metadata"
+<deegreeServicesMetadata xmlns="http://www.deegree.org/services/metadata"
                          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                         xsi:schemaLocation="http://www.deegree.org/services/metadata https://schemas.deegree.org/3.5/services/metadata/metadata.xsd">
+                         xsi:schemaLocation="http://www.deegree.org/services/metadata http://schemas.deegree.org/3.5/services/metadata/metadata.xsd">
 
   <ServiceIdentification>
     <Title>Strassenbaumkataster Hamburg</Title>


### PR DESCRIPTION
Updated the configVersion of the used configurations in the demo-workspace from 3.4.0 to 3.5.0. Furthermore added minor formatting changes.

The individually used schemaLocations need a review, since as of now https://schemas.deegree.org/3.5/ does not list the schemas for OGC API. 