### PR TITLE
Updated ogcapi-workspace: removed configVersion, updated schemaLocation

### DIFF
--- a/ogcapi-workspace/datasources/feature/kitaeinrichtung/datasource_kita_kitaeinrichtungen.xml
+++ b/ogcapi-workspace/datasources/feature/kitaeinrichtung/datasource_kita_kitaeinrichtungen.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<SQLFeatureStore configVersion="3.4.0"
-  xmlns="http://www.deegree.org/datasource/feature/sql" 
+<SQLFeatureStore xmlns="http://www.deegree.org/datasource/feature/sql"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  
-  xsi:schemaLocation="http://www.deegree.org/datasource/feature/sql http://schemas.deegree.org/datasource/feature/sql/3.4.0/sql.xsd">
+  xsi:schemaLocation="http://www.deegree.org/datasource/feature/sql https://schemas.deegree.org/core/3.5/datasource/feature/sql//sql.xsd">
   <JDBCConnId>oaf_db</JDBCConnId>
   <FeatureTypeMapping name="KitaEinrichtungen" table="kita.kita_einrichtung">
     <FIDMapping>

--- a/ogcapi-workspace/datasources/feature/strassenbaumkataster/datasource_strassenbaumkataster.xml
+++ b/ogcapi-workspace/datasources/feature/strassenbaumkataster/datasource_strassenbaumkataster.xml
@@ -1,7 +1,6 @@
-<SQLFeatureStore configVersion="3.4.0"
-                 xmlns="http://www.deegree.org/datasource/feature/sql"
+<SQLFeatureStore xmlns="http://www.deegree.org/datasource/feature/sql"
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                 xsi:schemaLocation="http://www.deegree.org/datasource/feature/sql http://schemas.deegree.org/datasource/feature/sql/3.4.0/sql.xsd">
+                 xsi:schemaLocation="http://www.deegree.org/datasource/feature/sql https://schemas.deegree.org/core/3.5/datasource/feature/sql/sql.xsd">
 
   <JDBCConnId>oaf_db</JDBCConnId>
   <StorageCRS srid="25832" dim="2D">http://www.opengis.net/def/crs/EPSG/0/25832</StorageCRS>

--- a/ogcapi-workspace/html/htmlview.xml
+++ b/ogcapi-workspace/html/htmlview.xml
@@ -1,5 +1,4 @@
-<HtmlView configVersion="3.4.0"
-          xmlns="http://www.deegree.org/ogcapi/htmlview"
+<HtmlView xmlns="http://www.deegree.org/ogcapi/htmlview"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://www.deegree.org/ogcapi/htmlview http://schemas.deegree.org/ogcapi/3.4.0/htmlview.xsd">
 

--- a/ogcapi-workspace/html/kitaeinrichtungview.xml
+++ b/ogcapi-workspace/html/kitaeinrichtungview.xml
@@ -1,5 +1,4 @@
-<HtmlView configVersion="3.4.0"
-          xmlns="http://www.deegree.org/ogcapi/htmlview"
+<HtmlView xmlns="http://www.deegree.org/ogcapi/htmlview"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://www.deegree.org/ogcapi/htmlview http://schemas.deegree.org/ogcapi/3.4.0/htmlview.xsd">
 

--- a/ogcapi-workspace/html/strassenbaumkatasterview.xml
+++ b/ogcapi-workspace/html/strassenbaumkatasterview.xml
@@ -1,5 +1,4 @@
-<HtmlView configVersion="3.4.0"
-          xmlns="http://www.deegree.org/ogcapi/htmlview"
+<HtmlView xmlns="http://www.deegree.org/ogcapi/htmlview"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://www.deegree.org/ogcapi/htmlview http://schemas.deegree.org/ogcapi/3.4.0/htmlview.xsd">
 

--- a/ogcapi-workspace/jdbc/oaf_db.xml
+++ b/ogcapi-workspace/jdbc/oaf_db.xml
@@ -1,7 +1,6 @@
-<DataSourceConnectionProvider configVersion="3.4.0"
-                              xmlns="http://www.deegree.org/connectionprovider/datasource"
+<DataSourceConnectionProvider xmlns="http://www.deegree.org/connectionprovider/datasource"
                               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                              xsi:schemaLocation="http://www.deegree.org/connectionprovider/datasource http://schemas.deegree.org/jdbc/datasource/3.4.0/datasource.xsd">
+                              xsi:schemaLocation="http://www.deegree.org/connectionprovider/datasource https://schemas.deegree.org/core/3.5/connectionprovider/datasource/datasource.xsd">
 
   <!-- Creation / lookup of javax.sql.DataSource instance -->
   <DataSource javaClass="org.apache.commons.dbcp.BasicDataSource" destroyMethod="close"/>

--- a/ogcapi-workspace/ogcapi/datasets.xml
+++ b/ogcapi-workspace/ogcapi/datasets.xml
@@ -1,7 +1,6 @@
-<Datasets configVersion="3.4.0"
-                        xmlns="http://www.deegree.org/ogcapi/datasets"
-                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                        xsi:schemaLocation="http://www.deegree.org/ogcapi/datasets  http://schemas.deegree.org/ogcapi/datasets/3.4.0/datasets.xsd">
+<Datasets xmlns="http://www.deegree.org/ogcapi/datasets"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://www.deegree.org/ogcapi/datasets  http://schemas.deegree.org/ogcapi/datasets/3.4.0/datasets.xsd">
   <Title>Datasets des LGV HH</Title>
   <Description><![CDATA[Testdaten des <a href="https://www.hamburg.de/bsw/landesbetrieb-geoinformation-und-vermessung/" target="_blank">LGV HH</a>]]></Description>
   <Contact>

--- a/ogcapi-workspace/ogcapi/kitaeinrichtung.xml
+++ b/ogcapi-workspace/ogcapi/kitaeinrichtung.xml
@@ -1,5 +1,4 @@
-<deegreeOAF configVersion="3.4.0"
-            xmlns="http://www.deegree.org/ogcapi/features"
+<deegreeOAF xmlns="http://www.deegree.org/ogcapi/features"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://www.deegree.org/ogcapi/features http://schemas.deegree.org/ogcapi/features/3.4.0/features.xsd">
 

--- a/ogcapi-workspace/ogcapi/strassenbaumkataster.xml
+++ b/ogcapi-workspace/ogcapi/strassenbaumkataster.xml
@@ -1,5 +1,4 @@
-<deegreeOAF configVersion="3.4.0"
-            xmlns="http://www.deegree.org/ogcapi/features"
+<deegreeOAF xmlns="http://www.deegree.org/ogcapi/features"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://www.deegree.org/ogcapi/features http://schemas.deegree.org/ogcapi/features/3.4.0/features.xsd">
 

--- a/ogcapi-workspace/services/kitaeinrichtung_metadata.xml
+++ b/ogcapi-workspace/services/kitaeinrichtung_metadata.xml
@@ -1,4 +1,4 @@
-<deegreeServicesMetadata xmlns="http://www.deegree.org/services/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" configVersion="3.4.0" xsi:schemaLocation="http://www.deegree.org/services/metadata http://schemas.deegree.org/services/metadata/3.4.0/metadata.xsd">
+<deegreeServicesMetadata xmlns="http://www.deegree.org/services/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.deegree.org/services/metadata https://schemas.deegree.org/core/3.5/services/metadata/metadata.xsd">
   <ServiceIdentification>
     <Title>Kita Einrichtungen Hamburg</Title>
     <Abstract><![CDATA[Es werden täglich zwei Dateien generiert:

--- a/ogcapi-workspace/services/strassenbaumkataster_metadata.xml
+++ b/ogcapi-workspace/services/strassenbaumkataster_metadata.xml
@@ -1,7 +1,6 @@
-<deegreeServicesMetadata configVersion="3.4.0"
-                         xmlns="http://www.deegree.org/services/metadata"
+<deegreeServicesMetadata xmlns="http://www.deegree.org/services/metadata"
                          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                         xsi:schemaLocation="http://www.deegree.org/services/metadata http://schemas.deegree.org/services/metadata/3.4.0/metadata.xsd">
+                         xsi:schemaLocation="http://www.deegree.org/services/metadata https://schemas.deegree.org/core/3.5/services/metadata/metadata.xsd">
 
   <ServiceIdentification>
     <Title>Strassenbaumkataster Hamburg</Title>


### PR DESCRIPTION
Replaces #14 

Attribute configVersion was removed and schemaLocations in the core configuration files are updated. Schemas for OGC API are not available at https://schemas.deegree.org/ogcapi yet (schemaLocations are not adapted). 