### PR TITLE
Configure CRS of Kitaeinrichtungen to SRID 4326

### DIFF
--- a/ogcapi-workspace/datasources/feature/kitaeinrichtung/datasource_kita_kitaeinrichtungen.xml
+++ b/ogcapi-workspace/datasources/feature/kitaeinrichtung/datasource_kita_kitaeinrichtungen.xml
@@ -43,7 +43,7 @@
     </Primitive>
     <Primitive mapping="leistungsart_name" path="Leistungsarten" />
     <Geometry mapping="the_geom" path="geom">
-      <StorageCRS srid="25832">EPSG:25832</StorageCRS>
+      <StorageCRS srid="4326">http://www.opengis.net/def/crs/OGC/1.3/CRS84</StorageCRS>
     </Geometry>
   </FeatureTypeMapping>
 </SQLFeatureStore>

--- a/ogcapi-workspace/datasources/feature/kitaeinrichtung/datasource_kita_kitaeinrichtungen.xml
+++ b/ogcapi-workspace/datasources/feature/kitaeinrichtung/datasource_kita_kitaeinrichtungen.xml
@@ -43,7 +43,7 @@
     </Primitive>
     <Primitive mapping="leistungsart_name" path="Leistungsarten" />
     <Geometry mapping="the_geom" path="geom">
-      <StorageCRS srid="4326">http://www.opengis.net/def/crs/OGC/1.3/CRS84</StorageCRS>
+      <StorageCRS srid="4326">EPSG:4326</StorageCRS>
     </Geometry>
   </FeatureTypeMapping>
 </SQLFeatureStore>

--- a/ogcapi-workspace/html/kitaeinrichtungview.xml
+++ b/ogcapi-workspace/html/kitaeinrichtungview.xml
@@ -9,7 +9,7 @@
   <Map>
     <WMSUrl version="1.3.0">https://sgx.geodatenzentrum.de/wms_topplus_open</WMSUrl>
     <WMSLayers>web_grau</WMSLayers>
-    <CrsProj4Definition code="EPSG:25832">+proj=utm +zone=32 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs
+    <CrsProj4Definition code="EPSG:4326">+proj=longlat +datum=WGS84 +no_defs +type=crs
     </CrsProj4Definition>
     <Source><![CDATA[© <a href="https://sg.geodatenzentrum.de/web_public/Datenquellen_TopPlus_Open.pdf" target="_new">Datenquellen</a>]]></Source>
   </Map>


### PR DESCRIPTION
This pull request changes the StorageCRS of Kitaeinrichtungen to SRID 4326.

In addition, the map preview of the HTML view of Kitaeinrichtungen is also configured to use EPSG:4326.