### PR TITLE
deegree-workspace-ogcri: Revert deletion of TileMatrixSet

### DIFF
--- a/deegree-workspace-ogcri/datasources/tile/tilematrixset/InspireCrs84Quad.xml
+++ b/deegree-workspace-ogcri/datasources/tile/tilematrixset/InspireCrs84Quad.xml
@@ -1,0 +1,170 @@
+<TileMatrixSet xmlns="http://www.deegree.org/datasource/tile/tilematrixset" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.deegree.org/datasource/tile/tilematrixset http://schemas.deegree.org/datasource/tile/tilematrixset/3.2.0/tilematrixset.xsd"
+  configVersion="3.2.0">
+
+  <CRS>urn:ogc:def:crs:OGC:1.3:CRS84</CRS>
+
+  <TileMatrix>
+    <Identifier>0</Identifier>
+    <ScaleDenominator>279541132.0143589</ScaleDenominator>
+    <TopLeftCorner>-180 90</TopLeftCorner>
+    <TileWidth>256</TileWidth>
+    <TileHeight>256</TileHeight>
+    <MatrixWidth>2</MatrixWidth>
+    <MatrixHeight>1</MatrixHeight>
+  </TileMatrix>
+  <TileMatrix>
+    <Identifier>1</Identifier>
+    <ScaleDenominator>139770566.0071794</ScaleDenominator>
+    <TopLeftCorner>-180 90</TopLeftCorner>
+    <TileWidth>256</TileWidth>
+    <TileHeight>256</TileHeight>
+    <MatrixWidth>4</MatrixWidth>
+    <MatrixHeight>2</MatrixHeight>
+  </TileMatrix>
+  <TileMatrix>
+    <Identifier>2</Identifier>
+    <ScaleDenominator>69885283.00358972</ScaleDenominator>
+    <TopLeftCorner>-180 90</TopLeftCorner>
+    <TileWidth>256</TileWidth>
+    <TileHeight>256</TileHeight>
+    <MatrixWidth>8</MatrixWidth>
+    <MatrixHeight>4</MatrixHeight>
+  </TileMatrix>
+  <TileMatrix>
+    <Identifier>3</Identifier>
+    <ScaleDenominator>34942641.50179486</ScaleDenominator>
+    <TopLeftCorner>-180 90</TopLeftCorner>
+    <TileWidth>256</TileWidth>
+    <TileHeight>256</TileHeight>
+    <MatrixWidth>16</MatrixWidth>
+    <MatrixHeight>8</MatrixHeight>
+  </TileMatrix>
+  <TileMatrix>
+    <Identifier>4</Identifier>
+    <ScaleDenominator>17471320.75089743</ScaleDenominator>
+    <TopLeftCorner>-180 90</TopLeftCorner>
+    <TileWidth>256</TileWidth>
+    <TileHeight>256</TileHeight>
+    <MatrixWidth>32</MatrixWidth>
+    <MatrixHeight>16</MatrixHeight>
+  </TileMatrix>
+  <TileMatrix>
+    <Identifier>5</Identifier>
+    <ScaleDenominator>8735660.375448715</ScaleDenominator>
+    <TopLeftCorner>-180 90</TopLeftCorner>
+    <TileWidth>256</TileWidth>
+    <TileHeight>256</TileHeight>
+    <MatrixWidth>64</MatrixWidth>
+    <MatrixHeight>32</MatrixHeight>
+  </TileMatrix>
+  <TileMatrix>
+    <Identifier>6</Identifier>
+    <ScaleDenominator>4367830.187724357</ScaleDenominator>
+    <TopLeftCorner>-180 90</TopLeftCorner>
+    <TileWidth>256</TileWidth>
+    <TileHeight>256</TileHeight>
+    <MatrixWidth>128</MatrixWidth>
+    <MatrixHeight>64</MatrixHeight>
+  </TileMatrix>
+  <TileMatrix>
+    <Identifier>7</Identifier>
+    <ScaleDenominator>2183915.093862179</ScaleDenominator>
+    <TopLeftCorner>-180 90</TopLeftCorner>
+    <TileWidth>256</TileWidth>
+    <TileHeight>256</TileHeight>
+    <MatrixWidth>256</MatrixWidth>
+    <MatrixHeight>128</MatrixHeight>
+  </TileMatrix>
+  <TileMatrix>
+    <Identifier>8</Identifier>
+    <ScaleDenominator>1091957.546931089</ScaleDenominator>
+    <TopLeftCorner>-180 90</TopLeftCorner>
+    <TileWidth>256</TileWidth>
+    <TileHeight>256</TileHeight>
+    <MatrixWidth>512</MatrixWidth>
+    <MatrixHeight>256</MatrixHeight>
+  </TileMatrix>
+  <TileMatrix>
+    <Identifier>9</Identifier>
+    <ScaleDenominator>545978.7734655447</ScaleDenominator>
+    <TopLeftCorner>-180 90</TopLeftCorner>
+    <TileWidth>256</TileWidth>
+    <TileHeight>256</TileHeight>
+    <MatrixWidth>1024</MatrixWidth>
+    <MatrixHeight>512</MatrixHeight>
+  </TileMatrix>
+  <TileMatrix>
+    <Identifier>10</Identifier>
+    <ScaleDenominator>272989.3867327723</ScaleDenominator>
+    <TopLeftCorner>-180 90</TopLeftCorner>
+    <TileWidth>256</TileWidth>
+    <TileHeight>256</TileHeight>
+    <MatrixWidth>2048</MatrixWidth>
+    <MatrixHeight>1024</MatrixHeight>
+  </TileMatrix>
+  <TileMatrix>
+    <Identifier>11</Identifier>
+    <ScaleDenominator>136494.6933663862</ScaleDenominator>
+    <TopLeftCorner>-180 90</TopLeftCorner>
+    <TileWidth>256</TileWidth>
+    <TileHeight>256</TileHeight>
+    <MatrixWidth>4096</MatrixWidth>
+    <MatrixHeight>2048</MatrixHeight>
+  </TileMatrix>
+  <TileMatrix>
+    <Identifier>12</Identifier>
+    <ScaleDenominator>68247.34668319309</ScaleDenominator>
+    <TopLeftCorner>-180 90</TopLeftCorner>
+    <TileWidth>256</TileWidth>
+    <TileHeight>256</TileHeight>
+    <MatrixWidth>8192</MatrixWidth>
+    <MatrixHeight>4096</MatrixHeight>
+  </TileMatrix>
+  <TileMatrix>
+    <Identifier>13</Identifier>
+    <ScaleDenominator>34123.67334159654</ScaleDenominator>
+    <TopLeftCorner>-180 90</TopLeftCorner>
+    <TileWidth>256</TileWidth>
+    <TileHeight>256</TileHeight>
+    <MatrixWidth>16384</MatrixWidth>
+    <MatrixHeight>8192</MatrixHeight>
+  </TileMatrix>
+  <TileMatrix>
+    <Identifier>14</Identifier>
+    <ScaleDenominator>17061.83667079827</ScaleDenominator>
+    <TopLeftCorner>-180 90</TopLeftCorner>
+    <TileWidth>256</TileWidth>
+    <TileHeight>256</TileHeight>
+    <MatrixWidth>32768</MatrixWidth>
+    <MatrixHeight>16384</MatrixHeight>
+  </TileMatrix>
+  <TileMatrix>
+    <Identifier>15</Identifier>
+    <ScaleDenominator>8530.918335399136</ScaleDenominator>
+    <TopLeftCorner>-180 90</TopLeftCorner>
+    <TileWidth>256</TileWidth>
+    <TileHeight>256</TileHeight>
+    <MatrixWidth>65536</MatrixWidth>
+    <MatrixHeight>32768</MatrixHeight>
+  </TileMatrix>
+  <TileMatrix>
+    <Identifier>16</Identifier>
+    <ScaleDenominator>4265.459167699568</ScaleDenominator>
+    <TopLeftCorner>-180 90</TopLeftCorner>
+    <TileWidth>256</TileWidth>
+    <TileHeight>256</TileHeight>
+    <MatrixWidth>131072</MatrixWidth>
+    <MatrixHeight>65536</MatrixHeight>
+  </TileMatrix>
+  <TileMatrix>
+    <Identifier>17</Identifier>
+    <ScaleDenominator>2132.729583849784</ScaleDenominator>
+    <TopLeftCorner>-180 90</TopLeftCorner>
+    <TileWidth>256</TileWidth>
+    <TileHeight>256</TileHeight>
+    <MatrixWidth>262144</MatrixWidth>
+    <MatrixHeight>131072</MatrixHeight>
+  </TileMatrix>
+
+</TileMatrixSet>


### PR DESCRIPTION
Follow up to https://github.com/deegree/deegree-workspaces/pull/19.

TileMatrixSet had to be reverted as it is required for WMTS standard.