### PR TITLE
Revert "deegree-workspace-ogcri: Configure WMTS to use standard theme"

### DIFF
--- a/deegree-workspace-ogcri/datasources/remoteows/deegree-cite.xml
+++ b/deegree-workspace-ogcri/datasources/remoteows/deegree-cite.xml
@@ -1,0 +1,3 @@
+<RemoteWMS xmlns="http://www.deegree.org/remoteows/wms" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.deegree.org/remoteows/wms http://schemas.deegree.org/remoteows/wms/3.1.0/remotewms.xsd" configVersion="3.1.0">
+  <CapabilitiesDocumentLocation location="http://deegree3-demo.deegree.org/inspire-workspace/services/wms?request=GetCapabilities&amp;service=WMS&amp;version=1.1.1"/>
+</RemoteWMS>

--- a/deegree-workspace-ogcri/datasources/tile/deegree-cite-tiles.xml
+++ b/deegree-workspace-ogcri/datasources/tile/deegree-cite-tiles.xml
@@ -1,0 +1,26 @@
+<RemoteWMSTileStore xmlns="http://www.deegree.org/datasource/tile/remotewms" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.deegree.org/datasource/tile/remotewms http://schemas.deegree.org/datasource/tile/remotewms/3.2.0/remotewms.xsd" configVersion="3.2.0">
+
+  <!-- [1]: Id of the remote WMS to connect to -->
+  <RemoteWMSId>deegree-cite</RemoteWMSId>
+
+  <TileDataSet>
+    <Identifier>cite</Identifier>
+    <!-- [1]: Id entspricht dem Dateinamen der TileMatrixSet XML-Konfigurationsdatei -->
+    <TileMatrixSetId>InspireCrs84Quad</TileMatrixSetId>
+    <!-- [1]" image output format -->
+    <OutputFormat>image/png</OutputFormat>
+    <!-- [1]: WMS request parameters -->
+    <RequestParams>
+      <!-- [1] Comma-separated list of layer names -->
+      <Layers>AU.AdministrativeUnit</Layers>
+      <!-- [0..1] Comma-separated list of styles -->
+      <Styles>default</Styles>
+      <!-- [1] Image format -->
+      <Format>image/png</Format>
+      <!-- [1] CRS for querying the remote service -->
+      <CRS>EPSG:4326</CRS>
+    </RequestParams>
+  </TileDataSet>
+
+
+</RemoteWMSTileStore>

--- a/deegree-workspace-ogcri/layers/deegree-cite-tilelayers.xml
+++ b/deegree-workspace-ogcri/layers/deegree-cite-tilelayers.xml
@@ -1,0 +1,7 @@
+<TileLayers xmlns="http://www.deegree.org/layers/tile" xmlns:l="http://www.deegree.org/layers/base" xmlns:d="http://www.deegree.org/metadata/description" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.deegree.org/layers/tile http://schemas.deegree.org/layers/tile/3.2.0/tile.xsd" configVersion="3.2.0">
+  <TileLayer>
+    <l:Name>cite</l:Name>
+    <d:Title>cite</d:Title>
+    <TileDataSet tileStoreId="deegree-cite-tiles">cite</TileDataSet>
+  </TileLayer>
+</TileLayers>

--- a/deegree-workspace-ogcri/services/wmts100.xml
+++ b/deegree-workspace-ogcri/services/wmts100.xml
@@ -1,7 +1,7 @@
 <deegreeWMTS xmlns="http://www.deegree.org/services/wmts" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" configVersion="3.2.0" xsi:schemaLocation="http://www.deegree.org/services/wmts wmts.xsd">
 
   <ServiceConfiguration>
-    <ThemeId>theme</ThemeId>
+    <ThemeId>wmts-theme</ThemeId>
   </ServiceConfiguration>
 
 </deegreeWMTS>

--- a/deegree-workspace-ogcri/themes/wmts-theme.xml
+++ b/deegree-workspace-ogcri/themes/wmts-theme.xml
@@ -1,0 +1,16 @@
+<Themes xmlns="http://www.deegree.org/themes/standard" xmlns:d="http://www.deegree.org/metadata/description" xmlns:s="http://www.deegree.org/metadata/spatial" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" configVersion="3.2.0" xsi:schemaLocation="http://www.deegree.org/themes/standard http://schemas.deegree.org/themes/3.2.0/themes.xsd">
+
+  <LayerStoreId>deegree-cite-tilelayers</LayerStoreId>
+
+  <Theme>
+    <Identifier>base</Identifier>
+    <d:Title>Root theme</d:Title>
+    <s:CRS>urn:ogc:def:crs:EPSG::4326</s:CRS>
+    <Theme>
+      <Identifier>cite</Identifier>
+      <d:Title>cite</d:Title>
+      <Layer>cite</Layer>
+    </Theme>
+  </Theme>
+
+</Themes>


### PR DESCRIPTION
Reverts deegree/deegree-workspaces#19

Reason: WMTS layer requires TileMatrixSet to be compliant to WMTS standard.