### PR TITLE
deegree-workspace-ogcri: Change remote OWS

### DIFF
--- a/deegree-workspace-ogcri/datasources/remoteows/deegree-cite.xml
+++ b/deegree-workspace-ogcri/datasources/remoteows/deegree-cite.xml
@@ -1,3 +1,3 @@
 <RemoteWMS xmlns="http://www.deegree.org/remoteows/wms" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.deegree.org/remoteows/wms http://schemas.deegree.org/remoteows/wms/3.1.0/remotewms.xsd" configVersion="3.1.0">
-  <CapabilitiesDocumentLocation location="http://deegree3-demo.deegree.org/inspire-workspace/services/wms?request=GetCapabilities&amp;service=WMS&amp;version=1.1.1"/>
+  <CapabilitiesDocumentLocation location="https://www.wms.nrw.de/geobasis/wms_nw_dop_overlay?REQUEST=GetCapabilities&amp;SERVICE=WMS&amp;version=1.1.1"/>
 </RemoteWMS>

--- a/deegree-workspace-ogcri/datasources/tile/deegree-cite-tiles.xml
+++ b/deegree-workspace-ogcri/datasources/tile/deegree-cite-tiles.xml
@@ -12,7 +12,7 @@
     <!-- [1]: WMS request parameters -->
     <RequestParams>
       <!-- [1] Comma-separated list of layer names -->
-      <Layers>AU.AdministrativeUnit</Layers>
+      <Layers>WMS_NW_DOP_OVERLAY</Layers>
       <!-- [0..1] Comma-separated list of styles -->
       <Styles>default</Styles>
       <!-- [1] Image format -->


### PR DESCRIPTION
Background: Dependency to demo instance shall be removed. This is required to work on https://github.com/deegree/deegree3/issues/1790 to prevent a circular dependency.

Instead, https://www.wms.nrw.de/geobasis/wms_nw_dop_overlay is used.